### PR TITLE
Fix always fallback and anonymous bind

### DIFF
--- a/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
+++ b/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
@@ -126,6 +126,9 @@ class WecosLDAPClient {
      */
     function connect_user($password, $dn) {
         $func = 'connect_user';
+        if(!$password) {
+            return $this->set_error($func, 'Anonymous bind denied');
+        }
         
         if (($this->ldap_con = @ldap_connect(
                                             $this->ldap_param['connectionHost'],
@@ -168,6 +171,9 @@ class WecosLDAPClient {
      */
     function checkPassword($username, $password) {
         $func = 'checkPassword';
+        if(!$password) {
+            return $this->set_error($func, 'Empty password supplied');
+        }
 
         if ($this->connect_default()) {
             $filter = sprintf($this->ldap_param['userSearch'], self::escape($username));

--- a/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/wxAuthLDAP.class.php
+++ b/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/wxAuthLDAP.class.php
@@ -47,7 +47,7 @@ class Plugins_Authentication_WxAuthLDAP_WxAuthLDAP extends Plugins_Authenticatio
             $doUser->find();
 
             if ($doUser->fetch()) {
-                return parent::checkPassword($username, $doUser->password, $allowMd5);
+                return $doUser;
             }
             OA::debug("WxAuthLDAP: User '".$username."' authenticated by LDAP, but no matching OpenX user exists.");
         } else {


### PR DESCRIPTION
In the first commit I removed the fallback to `parent::checkPassword` when the LDAP authentication was successful.
In the old code the local authentication is performed if LDAP authentication has success and I think it is not needed, else it will require the LDAP user's password written in the db too.

In the second commit I fixed a vulnerability: if someone while logging-in submits an empty password (and trust me, you can do it really easy) the `ldap_bind` will perform an anonymous bind which return always `true` on certain LDAP server configurations (for example default AD).