### PR TITLE
Better escaping username and autocomplete

### DIFF
--- a/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
+++ b/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
@@ -233,8 +233,7 @@ class WecosLDAPClient {
                 $c = dechex($c);
                 $ret .= '\\'.((strlen($c) != 2) ? '0'.$c : $c);
             } else {
-                // & ( ) * , ; = \ |
-                if (in_array($c, array(38, 40, 41, 42, 44, 59, 61, 92, 124))) {
+                if (strpos('&()*,;=\\|', chr($c)) !== false) {
                     $ret .= '\\';
                 }
                 $ret .= chr($c);

--- a/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
+++ b/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
@@ -233,7 +233,8 @@ class WecosLDAPClient {
                 $c = dechex($c);
                 $ret .= '\\'.((strlen($c) != 2) ? '0'.$c : $c);
             } else {
-                if ($c == ord('(') || $c == ord(')') || $c == ord('*') || $c == ord('\\')) {
+                // & ( ) * , ; = \ | =
+                if (in_array($c, array(38, 40, 41, 42, 44, 59, 61, 92, 124, 61))) {
                     $ret .= '\\';
                 }
                 $ret .= chr($c);

--- a/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
+++ b/wecosAuthLDAP/plugins/authentication/wxAuthLDAP/WecosLDAPClient.php
@@ -233,8 +233,8 @@ class WecosLDAPClient {
                 $c = dechex($c);
                 $ret .= '\\'.((strlen($c) != 2) ? '0'.$c : $c);
             } else {
-                // & ( ) * , ; = \ | =
-                if (in_array($c, array(38, 40, 41, 42, 44, 59, 61, 92, 124, 61))) {
+                // & ( ) * , ; = \ |
+                if (in_array($c, array(38, 40, 41, 42, 44, 59, 61, 92, 124))) {
                     $ret .= '\\';
                 }
                 $ret .= chr($c);

--- a/wecosAuthLDAP/www/admin/plugins/wxTestLDAP/wxTestLDAP.php
+++ b/wecosAuthLDAP/www/admin/plugins/wxTestLDAP/wxTestLDAP.php
@@ -56,7 +56,7 @@ if (isset($session['wxTestLDAP'])) {
    <input name="name" type="text" />
    <br />
    Password:<br />
-   <input name="pw" type="password" />
+   <input name="pw" type="password" autocomplete="off" />
    <br />
    <br />
    <input type="submit" name="testLDAP" value="Test LDAP Login" />


### PR DESCRIPTION
In this commit I added the escaping of `; , | & =` and `autocomplete="off"` in the psw field of testLDAP